### PR TITLE
Added High Power Feature for RFM69HCW

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - high-power-mode
   pull_request:
 
 env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - high-power-mode
   pull_request:
 
 env:

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -447,3 +447,9 @@ impl core::ops::BitAnd<IrqFlags2> for u8 {
         self & rhs as Self
     }
 }
+
+pub enum PaOptions {
+    Pa0On = 0x80,
+    Pa1On = 0x40,
+    Pa2On = 0x20,
+}

--- a/src/rfm.rs
+++ b/src/rfm.rs
@@ -398,9 +398,11 @@ where
         };
 
         let reg_value = match adjusted_power {
-           p if p <= 13 => PaOptions::Pa1On as u8 | (adjusted_power + 18) as u8,
-           p if p >= 18 => (PaOptions::Pa1On as u8 | PaOptions::Pa2On as u8)| (adjusted_power + 11) as u8,
-           _ => (PaOptions::Pa1On as u8 | PaOptions::Pa2On as u8) | (adjusted_power + 14) as u8,
+            p if p <= 13 => PaOptions::Pa1On as u8 | (adjusted_power + 18) as u8,
+            p if p >= 18 => {
+                (PaOptions::Pa1On as u8 | PaOptions::Pa2On as u8) | (adjusted_power + 11) as u8
+            }
+            _ => (PaOptions::Pa1On as u8 | PaOptions::Pa2On as u8) | (adjusted_power + 14) as u8,
         };
 
         self.write(Registers::PaLevel, reg_value)?;

--- a/src/rfm.rs
+++ b/src/rfm.rs
@@ -3,8 +3,8 @@ use core::convert::TryInto;
 use crate::error::{Error, Result};
 use crate::registers::{
     ContinuousDagc, DioMapping, DioPin, FifoMode, IrqFlags1, IrqFlags2, LnaConfig, Mode,
-    Modulation, Pa13dBm1, Pa13dBm2, PacketConfig, PacketFormat, Registers, RxBw, RxBwFreq,
-    SensitivityBoost,
+    Modulation, Pa13dBm1, Pa13dBm2, PaOptions, PacketConfig, PacketFormat, Registers, RxBw,
+    RxBwFreq, SensitivityBoost,
 };
 use crate::rw::ReadWrite;
 
@@ -283,7 +283,7 @@ where
         self.mode(Mode::Transmitter)?;
         while !self.is_packet_sent()? {}
 
-        // If the trasnmit power is over 18, turn off boost mode
+        // If the trasnmit power is over 18, turn off boost mode after sending message
         if self.tx_pwr >= 18 {
             self.disable_high_power()?;
         }
@@ -307,6 +307,12 @@ where
         self.reset_fifo()?;
 
         self.write(Registers::Fifo, packet_size)?;
+
+        // If the trasnmit power is over 18, turn on boost mode
+        if self.tx_pwr >= 18 {
+            self.enable_high_power()?;
+        }
+
         self.mode(Mode::Transmitter)?;
 
         for b in buffer {
@@ -315,6 +321,11 @@ where
         }
 
         while !self.is_packet_sent()? {}
+
+        // If the trasnmit power is over 18, turn off boost mode after sending message
+        if self.tx_pwr >= 18 {
+            self.disable_high_power()?;
+        }
 
         self.mode(Mode::Standby)
     }
@@ -366,9 +377,39 @@ where
     }
 
     pub fn tx_level(&mut self, power_level: i8, is_high_power: bool) -> Result<(), Espi> {
+        let mut reg_value: u8 = 0x00;
+        let mut pwr_level: i8 = power_level;
+
         if is_high_power {
-            // Write the power level
+            if pwr_level <= -2 {
+                pwr_level = -2;
+            }
+            if pwr_level <= 13 {
+                reg_value = PaOptions::Pa1On as u8 | ((pwr_level + 18) as u8 & 0x1F);
+            }
+            if pwr_level >= 18 {
+                if pwr_level > 20 {
+                    pwr_level = 20;
+                }
+                // both PA0 and PA1 should be turned on
+                reg_value = (PaOptions::Pa1On as u8 | PaOptions::Pa2On as u8)
+                    | (pwr_level + 11) as u8 & 0x1F;
+            } else {
+                reg_value = PaOptions::Pa1On as u8 | (pwr_level + 14) as u8 & 0x1F;
+            }
+        } else {
+            if pwr_level < -18 {
+                pwr_level = -18;
+            }
+
+            if pwr_level > 13 {
+                pwr_level = 13;
+            }
+
+            reg_value = PaOptions::Pa0On as u8 | (pwr_level + 18) as u8 & 0x1F;
         }
+
+        self.write(Registers::PaLevel, reg_value)?;
         self.tx_pwr = power_level;
         Ok(())
     }

--- a/src/rfm.rs
+++ b/src/rfm.rs
@@ -377,11 +377,7 @@ where
     }
 
     pub fn tx_level(&mut self, power_level: i8) -> Result<(), Espi> {
-        let adjusted_power = match power_level {
-            p if p < -18 => -18,
-            p if p > 13 => 13,
-            p => p,
-        };
+        let adjusted_power = power_level.clamp(-18, 13);
 
         let reg_value = PaOptions::Pa0On as u8 | (adjusted_power + 18) as u8;
 
@@ -391,11 +387,7 @@ where
     }
 
     pub fn tx_level_high_pwr(&mut self, power_level: i8) -> Result<(), Espi> {
-        let adjusted_power = match power_level {
-            p if p < -2 => -2,
-            p if p > 20 => 20,
-            p => p,
-        };
+        let adjusted_power = power_level.clamp(-2, 20);
 
         let reg_value = match adjusted_power {
             p if p <= 13 => PaOptions::Pa1On as u8 | (adjusted_power + 18) as u8,

--- a/src/rfm.rs
+++ b/src/rfm.rs
@@ -367,11 +367,10 @@ where
 
     pub fn tx_level(&mut self, power_level: i8, is_high_power: bool) -> Result<(), Espi> {
         if is_high_power {
-           // Write the power level 
+            // Write the power level
         }
         self.tx_pwr = power_level;
         Ok(())
-
     }
 
     fn enable_high_power(&mut self) -> Result<(), Espi> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -500,3 +500,51 @@ fn test_is_packet_sent() {
     assert!(rfm.is_packet_sent().ok().unwrap());
     assert_eq!(rfm.spi.rx_buffer[0], Registers::IrqFlags2.read());
 }
+
+// Test Tx Level
+
+#[test]
+fn test_tx_level_hp_min() {
+    // high power min is -2
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level(-3, true).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x50]);
+}
+
+#[test]
+fn test_tx_level_hp_max() {
+    // high power max is 20
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level(21, true).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x7f]);
+}
+
+#[test]
+fn test_tx_level_hp_mid() {
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level(15, true).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x5d]);
+}
+
+#[test]
+fn test_tx_level_lp_min() {
+    // Low Power min is -18
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level(-19, false).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x80]);
+}
+
+#[test]
+fn test_tx_level_lp_max() {
+    // Low power max is 13
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level(14, false).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x9f]);
+}
+
+#[test]
+fn test_tx_level_lp_mid() {
+    let mut rfm = setup_rfm(Vec::new(), vec![]);
+    assert!(rfm.tx_level(0, false).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x92]);
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -504,10 +504,10 @@ fn test_is_packet_sent() {
 // Test Tx Level
 
 #[test]
-fn test_tx_level_hp_min() {
+fn test_tx_level_high_pwr_min() {
     // high power min is -2
     let mut rfm = setup_rfm(Vec::new(), vec![]);
-    assert!(rfm.tx_level(-3, true).is_ok());
+    assert!(rfm.tx_level_high_pwr(-3).is_ok());
     assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x50]);
 }
 
@@ -515,22 +515,22 @@ fn test_tx_level_hp_min() {
 fn test_tx_level_hp_max() {
     // high power max is 20
     let mut rfm = setup_rfm(Vec::new(), vec![]);
-    assert!(rfm.tx_level(21, true).is_ok());
+    assert!(rfm.tx_level_high_pwr(21).is_ok());
     assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x7f]);
 }
 
 #[test]
 fn test_tx_level_hp_mid() {
     let mut rfm = setup_rfm(Vec::new(), vec![]);
-    assert!(rfm.tx_level(15, true).is_ok());
-    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x5d]);
+    assert!(rfm.tx_level_high_pwr(15).is_ok());
+    assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x7d]);
 }
 
 #[test]
 fn test_tx_level_lp_min() {
     // Low Power min is -18
     let mut rfm = setup_rfm(Vec::new(), vec![]);
-    assert!(rfm.tx_level(-19, false).is_ok());
+    assert!(rfm.tx_level(-19).is_ok());
     assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x80]);
 }
 
@@ -538,13 +538,13 @@ fn test_tx_level_lp_min() {
 fn test_tx_level_lp_max() {
     // Low power max is 13
     let mut rfm = setup_rfm(Vec::new(), vec![]);
-    assert!(rfm.tx_level(14, false).is_ok());
+    assert!(rfm.tx_level(14).is_ok());
     assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x9f]);
 }
 
 #[test]
 fn test_tx_level_lp_mid() {
     let mut rfm = setup_rfm(Vec::new(), vec![]);
-    assert!(rfm.tx_level(0, false).is_ok());
+    assert!(rfm.tx_level(0).is_ok());
     assert_eq!(rfm.spi.rx_buffer[0..=1], [Registers::PaLevel.write(), 0x92]);
 }


### PR DESCRIPTION
Added two methods to the rfm69 struct

- tx_level can be used to set a tx level between -18 and 13 using the PA0
- tx_level_high_pwr can be used to set a tx level between -2 and 20 using PA1 or PA1 & PA2. 